### PR TITLE
adds a user-facing “Gallery” for uploaded/generated files: a new Gallery page in the web app, a gallery API route, and DB schema entries labeled with dataType: "gallery".

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from config import PARAMETER
-from routers import chat, file, streaming
+from routers import chat, file, gallery, streaming
 
 
 def setup_logging():
@@ -58,6 +58,7 @@ async def parameter():
 # Include routers
 app.include_router(chat.router)
 app.include_router(file.router)
+app.include_router(gallery.router)
 app.include_router(streaming.router)
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -62,3 +62,12 @@ class ToolSelectionResponse(BaseModel):
     awsDocumentation: bool
     codeInterpreter: bool
     webBrowser: bool
+
+
+class GalleryItem(BaseModel):
+    bucket: str
+    key: str
+    bucketRegion: str
+    filename: str
+    uploadedAt: str
+    userId: str

--- a/api/routers/gallery.py
+++ b/api/routers/gallery.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Header, HTTPException, Query
+
+from database import get_gallery_items_from_db
+
+router = APIRouter()
+
+
+@router.get("/api/gallery", response_model=dict)
+def get_gallery_items(x_user_sub: str = Header(...), limit: int | None = Query(20, ge=1, le=100), exclusive_start_key: str | None = Query(None)):
+    """Get gallery items for the current user, ordered by upload time (newest first)"""
+    try:
+        result = get_gallery_items_from_db(x_user_sub, exclusive_start_key, limit)
+
+        # Convert items to GalleryItem format for response
+        gallery_items = []
+        for item in result["items"]:
+            gallery_items.append({"bucket": item["bucket"], "key": item["key"], "bucketRegion": item["bucketRegion"], "filename": item["filename"], "uploadedAt": item["uploadedAt"], "userId": item["userId"]})
+
+        return {"items": gallery_items, "lastEvaluatedKey": result["lastEvaluatedKey"]}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve gallery items: {str(e)}") from e

--- a/api/services/streaming_service.py
+++ b/api/services/streaming_service.py
@@ -92,7 +92,7 @@ async def process_streaming_request(request: StreamingRequest, x_user_sub: str, 
                 }
 
             # Create session-aware upload tool
-            session_upload_tool = create_session_aware_upload_tool(session_workspace_dir)
+            session_upload_tool = create_session_aware_upload_tool(session_workspace_dir, x_user_sub)
 
             model = BedrockModel(**model_params)
             tools = [

--- a/api/tools.py
+++ b/api/tools.py
@@ -11,17 +11,20 @@ from s3 import upload_file_to_s3
 session_workspace_context: ContextVar[str] = ContextVar("session_workspace_context", default=None)
 
 
-def create_session_aware_upload_tool(session_workspace_dir: str):
+def create_session_aware_upload_tool(session_workspace_dir: str, x_user_sub: str = None):
     """Create a session-aware upload tool with the session workspace directory"""
 
     @tool
-    def upload_file_to_s3_and_retrieve_s3_url(filepath: str) -> str:
+    def upload_file_to_s3_and_retrieve_s3_url(filepath: str, user_sub: str = None) -> str:
         """Upload the file at session workspace and retrieve the s3 path
 
         Args:
             filepath: The path to the uploading file
+            user_sub: User subscription ID for gallery tracking
         """
-        return upload_file_to_s3(filepath, session_workspace_dir)
+        # Use provided user_sub or fall back to the session user_sub
+        effective_user_sub = user_sub or x_user_sub
+        return upload_file_to_s3(filepath, session_workspace_dir, effective_user_sub)
 
     return upload_file_to_s3_and_retrieve_s3_url
 

--- a/cdk/parameter.template.ts
+++ b/cdk/parameter.template.ts
@@ -13,9 +13,9 @@ export const parameter: Parameter = {
   // Model access must be enabled in the respective regions
   models: [
     {
-      id: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+      id: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
       region: 'us-east-1',
-      displayName: 'Claude Sonnet 4',
+      displayName: 'Claude Sonnet 4.5',
     },
     {
       id: 'us.anthropic.claude-opus-4-1-20250805-v1:0',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,13 +1,16 @@
 import { Suspense, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import Header from './components/Header';
 import Drawer from './components/Drawer';
 import Chat from './pages/Chat';
+import Gallery from './pages/Gallery';
 import { useTheme } from './hooks/useTheme';
 import { Toaster } from 'react-hot-toast';
 
 function App() {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const { theme } = useTheme();
+  const location = useLocation();
 
   const toggleDrawer = () => {
     setIsDrawerOpen(!isDrawerOpen);
@@ -15,6 +18,15 @@ function App() {
 
   const closeDrawer = () => {
     setIsDrawerOpen(false);
+  };
+
+  // Determine which page to render based on the current path
+  const renderCurrentPage = () => {
+    if (location.pathname === '/gallery') {
+      return <Gallery />;
+    } else {
+      return <Chat />;
+    }
   };
 
   return (
@@ -25,7 +37,7 @@ function App() {
         <div className="relative flex flex-1 overflow-hidden">
           <Drawer isOpen={isDrawerOpen} onClose={closeDrawer} />
 
-          <Chat />
+          {renderCurrentPage()}
 
           {isDrawerOpen && (
             <div

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import { useTheme } from '../hooks/useTheme';
 import useUser from '../hooks/useUser';
 import useChats from '../hooks/useChats';
+import Tooltip from './Tooltip';
 
 interface DrawerProps {
   isOpen: boolean;
@@ -219,29 +220,52 @@ function Drawer({ isOpen, onClose }: DrawerProps) {
           isOpen ? 'translate-x-0' : '-translate-x-full'
         }`}>
         <div className="flex flex-shrink-0 items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700">
-          <Link
-            to="/"
-            className="flex items-center rounded p-1 text-gray-700 transition-colors duration-300 hover:text-gray-900 focus:outline-none active:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100 dark:active:text-gray-200"
-            onClick={handleChatClick}>
-            <svg
-              className="h-6 w-6 transition-colors duration-300"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v8m-4-4h8"
-              />
-            </svg>
-          </Link>
+          <div className="flex items-center gap-2">
+            <Tooltip content="New chat" position="bottom">
+              <Link
+                to="/"
+                className="flex items-center rounded p-1 text-gray-700 transition-colors duration-300 hover:text-gray-900 focus:outline-none active:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100 dark:active:text-gray-200"
+                onClick={handleChatClick}>
+                <svg
+                  className="h-6 w-6 transition-colors duration-300"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v8m-4-4h8"
+                  />
+                </svg>
+              </Link>
+            </Tooltip>
+            <Tooltip content="Gallery" position="bottom">
+              <Link
+                to="/gallery"
+                className="flex items-center rounded p-1 text-gray-700 transition-colors duration-300 hover:text-gray-900 focus:outline-none active:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100 dark:active:text-gray-200"
+                onClick={handleChatClick}>
+                <svg
+                  className="h-6 w-6 transition-colors duration-300"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+              </Link>
+            </Tooltip>
+          </div>
           <ThemeToggle />
         </div>
 

--- a/web/src/components/GalleryImage.tsx
+++ b/web/src/components/GalleryImage.tsx
@@ -1,0 +1,120 @@
+import { memo, useState } from 'react';
+import useFile from '../hooks/useFile';
+import useSWR from 'swr';
+
+interface GalleryImageProps {
+  src: string;
+  alt?: string;
+  className?: string;
+}
+
+const GalleryImage = memo(({ src, alt, className = '' }: GalleryImageProps) => {
+  const { isS3, parseS3Url, downloadUrl } = useFile();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  const fetchDownloadUrl = async () => {
+    if (isS3(src)) {
+      const { key } = parseS3Url(src);
+      const url = await downloadUrl(key);
+      return url;
+    } else {
+      return src;
+    }
+  };
+
+  const { data: downloadSrc, isLoading } = useSWR(src, fetchDownloadUrl, {
+    suspense: false,
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateOnMount: true,
+    dedupingInterval: 300000, // 5 minutes
+  });
+
+  const handleImageClick = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      handleModalClose();
+    }
+  };
+
+  const handleDownload = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    window.open(downloadSrc, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleImageLoad = () => {
+    setImageLoaded(true);
+  };
+
+  // Loading state
+  if (isLoading || !downloadSrc) {
+    return (
+      <div
+        className={`flex animate-pulse items-center justify-center rounded bg-gray-200 dark:bg-gray-700 ${className}`}>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          Loading...
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="group relative">
+        <img
+          src={downloadSrc}
+          className={`cursor-pointer rounded object-cover transition-opacity duration-200 ${
+            imageLoaded ? 'opacity-100' : 'opacity-0'
+          } ${className}`}
+          onClick={handleImageClick}
+          onLoad={handleImageLoad}
+          alt={alt || ''}
+        />
+        {imageLoaded && (
+          <div className="absolute right-0 bottom-0 left-0 flex items-end justify-end rounded-b bg-gradient-to-t from-black/60 to-transparent p-2 opacity-100 lg:opacity-0 lg:transition-opacity lg:duration-300 lg:group-hover:opacity-100">
+            <button
+              onClick={handleDownload}
+              className="cursor-pointer text-white transition-colors duration-200 hover:text-gray-300">
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Expanded modal */}
+      {isModalOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4"
+          onClick={handleBackdropClick}>
+          <img
+            src={downloadSrc}
+            className="max-h-full max-w-full rounded object-contain"
+            alt={alt || ''}
+          />
+        </div>
+      )}
+    </>
+  );
+});
+
+export default GalleryImage;

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 import type { ChatInTable } from '@types';
 import useChatState from '../hooks/useChatState';
 import ModelDropdown from './ModelDropdown';
+import Tooltip from './Tooltip';
 
 interface HeaderProps {
   onToggleDrawer: () => void;
@@ -44,28 +45,50 @@ function Header({ onToggleDrawer }: HeaderProps) {
 
       <div className="hidden flex-1 lg:flex">
         <div className="flex items-center gap-3">
-          <Link
-            to="/"
-            className="flex items-center rounded-md p-2 transition-colors duration-300 hover:bg-gray-200 focus:outline-none active:bg-gray-300 dark:hover:bg-gray-700 dark:active:bg-gray-600">
-            <svg
-              className="h-6 w-6 text-gray-600 transition-colors duration-300 dark:text-gray-300"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v8m-4-4h8"
-              />
-            </svg>
-          </Link>
+          <div className="flex items-center gap-1">
+            <Tooltip content="New chat" position="bottom">
+              <Link
+                to="/"
+                className="flex items-center rounded-md p-2 transition-colors duration-300 hover:bg-gray-200 focus:outline-none active:bg-gray-300 dark:hover:bg-gray-700 dark:active:bg-gray-600">
+                <svg
+                  className="h-6 w-6 text-gray-600 transition-colors duration-300 dark:text-gray-300"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v8m-4-4h8"
+                  />
+                </svg>
+              </Link>
+            </Tooltip>
+            <Tooltip content="Gallery" position="bottom">
+              <Link
+                to="/gallery"
+                className="flex items-center rounded-md p-2 transition-colors duration-300 hover:bg-gray-200 focus:outline-none active:bg-gray-300 dark:hover:bg-gray-700 dark:active:bg-gray-600">
+                <svg
+                  className="h-6 w-6 text-gray-600 transition-colors duration-300 dark:text-gray-300"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+              </Link>
+            </Tooltip>
+          </div>
           <ModelDropdown
             selectedModel={selectedModel}
             models={availableModels}

--- a/web/src/hooks/useGallery.ts
+++ b/web/src/hooks/useGallery.ts
@@ -1,0 +1,23 @@
+import useGalleryApi, { GALLERY_PAGE_SIZE } from './useGalleryApi';
+import usePagination from './usePagination';
+
+const useGallery = () => {
+  const { getGalleryItems } = useGalleryApi();
+  const {
+    flattenData: galleryItems,
+    mutate: reloadGallery,
+    canLoadMore,
+    loadMore,
+    isLoading,
+  } = usePagination(getGalleryItems(), GALLERY_PAGE_SIZE);
+
+  return {
+    galleryItems,
+    reloadGallery,
+    canLoadMore,
+    loadMore,
+    isLoading,
+  };
+};
+
+export default useGallery;

--- a/web/src/hooks/useGalleryApi.ts
+++ b/web/src/hooks/useGalleryApi.ts
@@ -1,0 +1,44 @@
+import useApi from './useApi';
+import useSWRInfinite from 'swr/infinite';
+import { type Pagination } from '@types';
+
+export const GALLERY_PAGE_SIZE = 20;
+
+export type GalleryItem = {
+  bucket: string;
+  key: string;
+  bucketRegion: string;
+  filename: string;
+  uploadedAt: string;
+  userId: string;
+};
+
+const useGalleryApi = () => {
+  const { swrFetcher } = useApi();
+
+  const getGalleryItems = () => {
+    const getKey = (
+      pageIndex: number,
+      previousPageData: Pagination<GalleryItem>
+    ) => {
+      if (previousPageData && !previousPageData.lastEvaluatedKey) return null;
+      if (pageIndex === 0) return `gallery?limit=${GALLERY_PAGE_SIZE}`;
+      return `gallery?limit=${GALLERY_PAGE_SIZE}&exclusive_start_key=${encodeURIComponent(previousPageData.lastEvaluatedKey!)}`;
+    };
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    return useSWRInfinite<Pagination<GalleryItem>>(
+      getKey,
+      swrFetcher<Pagination<GalleryItem>>,
+      {
+        revalidateIfStale: false,
+      }
+    );
+  };
+
+  return {
+    getGalleryItems,
+  };
+};
+
+export default useGalleryApi;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -20,6 +20,10 @@ const router = createBrowserRouter([
     element: <App />,
   },
   {
+    path: '/gallery',
+    element: <App />,
+  },
+  {
     path: '*',
     element: <NotFound />,
   },

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -472,7 +472,9 @@ function Chat() {
               <div key={idx} className="mb-12">
                 <Message
                   message={m}
-                  loading={streaming && idx === messages.length - 1}
+                  loading={
+                    streaming && idx === messages.length - 1 && !isSelecting
+                  }
                 />
               </div>
             );
@@ -480,6 +482,17 @@ function Chat() {
         </div>
 
         {loading && messages.length === 0 && <Loading className="py-14" />}
+
+        {/* Tool selection loading indicator */}
+        {isSelecting && (
+          <div className="mb-12">
+            <div className="w-full text-gray-900 transition-colors duration-300 dark:text-gray-100">
+              <div className="flex h-8 items-center justify-center">
+                <Loading size="md" />
+              </div>
+            </div>
+          </div>
+        )}
 
         <div ref={scrollBottomAnchorRef}></div>
       </div>
@@ -635,7 +648,7 @@ function Chat() {
 
               {/* Desktop: Individual toggle buttons */}
               <div
-                className={`hidden lg:flex lg:gap-2 ${isAutoMode ? 'pointer-events-none opacity-50' : ''}`}>
+                className={`${isAutoMode ? 'hidden' : 'hidden lg:flex lg:gap-2'}`}>
                 {/* Reasoning toggle button */}
                 <Tooltip content="Reasoning">
                   <button

--- a/web/src/pages/Gallery.tsx
+++ b/web/src/pages/Gallery.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef, useCallback } from 'react';
+import useGallery from '../hooks/useGallery';
+import useScreen from '../hooks/useScreen';
+import GalleryImage from '../components/GalleryImage';
+import Loading from '../components/Loading';
+
+function Gallery() {
+  const { galleryItems, canLoadMore, loadMore, isLoading } = useGallery();
+  const { screen, isAtBottom, notifyScreen } = useScreen();
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Auto-load more items when scrolling to bottom
+  const handleScroll = useCallback(() => {
+    if (isAtBottom && canLoadMore && !isLoading) {
+      loadMore();
+    }
+  }, [isAtBottom, canLoadMore, isLoading, loadMore]);
+
+  useEffect(() => {
+    handleScroll();
+  }, [handleScroll]);
+
+  // Auto-load if content doesn't fill the container
+  useEffect(() => {
+    const checkAndLoadMore = () => {
+      if (!contentRef.current || !screen.current) return;
+
+      const containerHeight = screen.current.clientHeight;
+      const contentHeight = contentRef.current.scrollHeight;
+
+      // If content doesn't fill the container and we can load more
+      if (contentHeight <= containerHeight && canLoadMore && !isLoading) {
+        loadMore();
+      }
+    };
+
+    // Check after initial render and when items change
+    const timer = setTimeout(checkAndLoadMore, 100);
+    return () => clearTimeout(timer);
+  }, [galleryItems, canLoadMore, isLoading, loadMore]);
+
+  useEffect(() => {
+    notifyScreen();
+  }, [notifyScreen]);
+
+  return (
+    <div className="relative mt-14 flex min-w-0 flex-1 flex-col">
+      {/* Header */}
+      <div className="border-b border-gray-200 p-4 dark:border-gray-700">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          Gallery
+        </h1>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Your uploaded images and files
+        </p>
+      </div>
+
+      {/* Gallery content */}
+      <div ref={screen} className="custom-scrollbar flex-1 overflow-y-auto p-4">
+        <div ref={contentRef}>
+          {galleryItems.length === 0 && !isLoading ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <svg
+                className="mb-4 h-16 w-16 text-gray-400 dark:text-gray-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1}
+                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              <h3 className="mb-2 text-lg font-medium text-gray-900 dark:text-gray-100">
+                No images yet
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400">
+                Start a chat and upload some images to see them here.
+              </p>
+            </div>
+          ) : (
+            <>
+              {/* Responsive grid layout */}
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+                {galleryItems.map((item, index) => {
+                  // Create S3 URL from item data
+                  const s3Url = `s3://${item.bucket}/${item.key}`;
+
+                  return (
+                    <div key={index} className="aspect-square">
+                      <GalleryImage
+                        src={s3Url}
+                        alt={item.filename}
+                        className="h-full w-full"
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Loading indicator */}
+              {isLoading && (
+                <div className="flex justify-center py-8">
+                  <Loading className="text-gray-600 dark:text-gray-400" />
+                </div>
+              )}
+
+              {/* End of gallery message */}
+              {!canLoadMore && galleryItems.length > 0 && (
+                <div className="flex justify-center py-8">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    You've reached the end of your gallery
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Gallery;

--- a/web/src/pages/Gallery.tsx
+++ b/web/src/pages/Gallery.tsx
@@ -37,7 +37,7 @@ function Gallery() {
     // Check after initial render and when items change
     const timer = setTimeout(checkAndLoadMore, 100);
     return () => clearTimeout(timer);
-  }, [galleryItems, canLoadMore, isLoading, loadMore]);
+  }, [galleryItems, canLoadMore, isLoading, loadMore, screen]);
 
   useEffect(() => {
     notifyScreen();


### PR DESCRIPTION
Adds a Gallery feature end-to-end

API: New /api/gallery GET route that returns the current user’s items, ordered newest-first, with pagination (limit and exclusive_start_key). 


DB layer: New helpers to create a gallery item in DynamoDB when a file is uploaded and to query a user’s gallery (keys like queryId = <user_sub>$gallery, orderBy = timestamp). 

S3 upload integration: The upload flow now records uploads into the gallery, wiring the user’s sub through the tool and upload function so every upload is tracked (adds optional user_sub/x_user_sub and calls create_gallery_item_in_db). 

Web UI: Adds a /gallery page, a GalleryImage component, hooks (useGallery, useGalleryApi) and routing so the app can navigate between Chat and Gallery. 

Small follow-up fixes on the same day (two “fix” commits that the merge pulls in):

Auto-load bug on Gallery page: The effect that checks whether to fetch more items now includes screen in its dependency array to avoid missing a load when the viewport changes. 

Model parameter update (CDK): Updates the default model metadata from “Claude Sonnet 4” to “Claude Sonnet 4.5” in parameter.template.ts. (Not strictly gallery, but it’s in the associated fix commit.)