### PR TITLE
fix: add missing weather tool props to resolve TypeScript compilation…

### DIFF
--- a/web/src/hooks/useChatState.ts
+++ b/web/src/hooks/useChatState.ts
@@ -159,6 +159,7 @@ const useChatState = (chatId: string) => {
   const hasAwsDocumentation = currentTools.includes('awsDocumentation');
   const hasCodeInterpreter = currentTools.includes('codeInterpreter');
   const hasWebBrowser = currentTools.includes('webBrowser');
+  const hasWeather = currentTools.includes('weather');
 
   const toggleTool = useCallback(
     (toolName: string) => {
@@ -261,6 +262,19 @@ const useChatState = (chatId: string) => {
         setToolsToUseImpl(
           chatId,
           currentTools.filter((tool) => tool !== 'webBrowser')
+        );
+      }
+    },
+    weather: hasWeather,
+    setWeather: (enabled: boolean) => {
+      const currentTools = state.toolsToUse || [];
+      const hasThisTool = currentTools.includes('weather');
+      if (enabled && !hasThisTool) {
+        setToolsToUseImpl(chatId, [...currentTools, 'weather']);
+      } else if (!enabled && hasThisTool) {
+        setToolsToUseImpl(
+          chatId,
+          currentTools.filter((tool) => tool !== 'weather')
         );
       }
     },

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -79,6 +79,8 @@ function Chat() {
     setCodeInterpreter,
     webBrowser,
     setWebBrowser,
+    weather,              // ADD THIS
+    setWeather,
     selectedModel,
     setSelectedModel,
     availableModels,
@@ -212,6 +214,7 @@ function Chat() {
           if (toolSelection.codeInterpreter)
             finalToolsToUse.push('codeInterpreter');
           if (toolSelection.webBrowser) finalToolsToUse.push('webBrowser');
+          if (toolSelection.weather) finalToolsToUse.push('weather');
         }
       } catch (error) {
         console.error('Failed to auto-select tools:', error);
@@ -866,6 +869,8 @@ function Chat() {
         onCodeInterpreterChange={setCodeInterpreter}
         webBrowser={webBrowser}
         onWebBrowserChange={setWebBrowser}
+        weather={weather}
+        onWeatherChange={setWeather}
       />
     </div>
   );


### PR DESCRIPTION
… error

Add weather state management to useChatState hook and pass weather props to ToolsBottomSheet component in Chat.tsx. This resolves the TypeScript error TS2739 that was causing CDK deployment build failures.

Changes:
- useChatState.ts: Add hasWeather state and setWeather handler
- Chat.tsx: Destructure weather/setWeather from useChatState and pass to ToolsBottomSheet component
- Chat.tsx: Include weather in executeChatStreamWithToolSelection logic

Fixes build error: "Type is missing the following properties from type
'ToolsBottomSheetProps': weather, onWeatherChange"